### PR TITLE
fix: prevent http server's shutdown with a closed ctx

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func main() {
 	}()
 
 	if err := run(ctx); err != nil {
-		os.Exit(1)
+		log.Fatal().Err(err)
 	}
 }
 
@@ -82,7 +82,10 @@ func run(ctx context.Context) error {
 	errGroup.Go(func() error {
 		<-ctx.Done()
 		log.Debug().Msg("shutting down application")
-		if err := httpServer.Shutdown(ctx); err != nil {
+		timeout, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		defer cancel()
+
+		if err := httpServer.Shutdown(timeout); err != nil {
 			return fmt.Errorf("failed to shutdown http server: %w", err)
 		}
 

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func main() {
 	}()
 
 	if err := run(ctx); err != nil {
-		log.Fatal().Err(err)
+		log.Fatal().Err(err).Msg("application shutdown with an error")
 	}
 }
 


### PR DESCRIPTION
Hi @arthureichelberger,
After your comment about testing the context cancelling and how this service would behave I ended up doing some digging as well and learnt that due to `if err := httpServer.Shutdown(ctx); err != nil` the application seems to always crash whenever it receives a termination signal from the OS, because by then the ctx will already have been closed.

Here are the logs I get:
```
{"level":"debug","time":"2024-02-16T11:18:39Z","message":"shutting down application"}
{"level":"debug","time":"2024-02-16T11:18:39Z","message":"run() err: failed to run application: failed to shutdown http server: context canceled\n"}
exit status 1
```

Here is the branch I used to perform such a test: https://github.com/arthureichelberger/goboiler/compare/master...flowck:goboiler:begin?expand=1

### Proposal

A new ctx is created with a timeout, which can be defined as a env variable to parameterise its duration, thus giving the http server some time to shut itself down or else the ctx timeout kicks in.

