### PR TITLE
feat: add transactor support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .idea/
-./unit-tests.xml
+unit-tests.xml
 dist/

--- a/internal/service/dummy_service.go
+++ b/internal/service/dummy_service.go
@@ -5,22 +5,37 @@ import (
 	"fmt"
 
 	"github.com/arthureichelberger/goboiler/internal/store"
+	"github.com/arthureichelberger/goboiler/pkg/psql"
 	"github.com/rs/zerolog/log"
 )
 
 type DummyService struct {
 	dummyStore store.DummyStore
+	transactor psql.Transactor
 }
 
-func NewDummyService(dummyStore store.DummyStore) DummyService {
+func NewDummyService(dummyStore store.DummyStore, transactor psql.Transactor) DummyService {
 	return DummyService{
 		dummyStore: dummyStore,
+		transactor: transactor,
 	}
 }
 
 func (s DummyService) Dummy(ctx context.Context) (int64, error) {
-	count, err := s.dummyStore.Dummy(ctx)
-	if err != nil {
+	var count int64
+
+	op := func(ctx context.Context) error {
+		var err error
+		count, err = s.dummyStore.Dummy(ctx)
+		if err != nil {
+			log.Ctx(ctx).Error().Err(err).Msg("failed to dummy")
+			return fmt.Errorf("failed to dummy: %w", err)
+		}
+
+		return nil
+	}
+
+	if err := s.transactor.WithinTransaction(ctx, op); err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("failed to dummy")
 		return 0, fmt.Errorf("failed to dummy: %w", err)
 	}

--- a/internal/service/dummy_service_test.go
+++ b/internal/service/dummy_service_test.go
@@ -24,7 +24,7 @@ func TestDummy(t *testing.T) {
 	t.Cleanup(rollback)
 
 	dummyStore := store.NewDummyStore(txn)
-	dummyService := service.NewDummyService(dummyStore)
+	dummyService := service.NewDummyService(dummyStore, psql.NewTransactor(txn(ctx)))
 
 	t.Run("it should return the correct value", func(t *testing.T) {
 		count, err := dummyService.Dummy(ctx)

--- a/internal/store/dummy_store.go
+++ b/internal/store/dummy_store.go
@@ -12,10 +12,10 @@ type DummyStore interface {
 }
 
 type dummyStore struct {
-	db psql.Queryable
+	db psql.DBGetter
 }
 
-func NewDummyStore(db psql.Queryable) DummyStore {
+func NewDummyStore(db psql.DBGetter) DummyStore {
 	return dummyStore{
 		db: db,
 	}
@@ -25,7 +25,7 @@ func (s dummyStore) Dummy(ctx context.Context) (int64, error) {
 	query := `SELECT 1+1 as result`
 
 	var count int64
-	if err := s.db.GetContext(ctx, &count, query); err != nil {
+	if err := s.db(ctx).GetContext(ctx, &count, query); err != nil {
 		return 0, fmt.Errorf("failed to dummy: %w", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -58,11 +58,13 @@ func run(parent context.Context) error {
 		return fmt.Errorf("failed to connect to database: %w", err)
 	}
 
+	transactor := psql.NewTransactor(db(ctx))
+
 	// stores
 	dummyStore := store.NewDummyStore(db)
 
 	// services
-	dummyService := service.NewDummyService(dummyStore)
+	dummyService := service.NewDummyService(dummyStore, transactor)
 
 	router := gin.New()
 	router.Use(cors.New(cors.Config{

--- a/pkg/psql/transactor.go
+++ b/pkg/psql/transactor.go
@@ -1,0 +1,103 @@
+package psql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+
+	"github.com/jmoiron/sqlx"
+)
+
+type Transactor interface {
+	WithinTransaction(context.Context, func(ctx context.Context) error) error
+}
+
+type transactor struct {
+	db Queryable
+}
+
+func NewTransactor(db Queryable) Transactor {
+	return &transactor{db: db}
+}
+
+type txCtxKey struct{}
+
+func txToContext(ctx context.Context, tx Queryable) context.Context {
+	return context.WithValue(ctx, txCtxKey{}, &TxQueryable{Queryable: tx})
+}
+
+func TxFromContext(ctx context.Context) Queryable {
+	tx, ok := ctx.Value(txCtxKey{}).(Queryable)
+	if ok {
+		return tx
+	}
+
+	return nil
+}
+
+func (t *transactor) WithinTransaction(ctx context.Context, txFunc func(txCtx context.Context) error) error {
+	tx, err := t.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+
+	txCtx := txToContext(ctx, tx)
+	if err := txFunc(txCtx); err != nil {
+		tx.Rollback() // nolint: errcheck // If rollback fails, there's nothing to do, the transaction will expire by itself
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+type TxQueryable struct {
+	Queryable
+	sync.Mutex
+}
+
+func (t *TxQueryable) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	t.Lock()
+	defer t.Unlock()
+
+	return t.Queryable.ExecContext(ctx, query, args...) // nolint:wrapcheck
+}
+
+func (t *TxQueryable) GetContext(ctx context.Context, dest any, query string, args ...any) error {
+	t.Lock()
+	defer t.Unlock()
+
+	return t.Queryable.GetContext(ctx, dest, query, args...) // nolint:wrapcheck
+}
+
+func (t *TxQueryable) SelectContext(ctx context.Context, dest any, query string, args ...any) error {
+	t.Lock()
+	defer t.Unlock()
+
+	return t.Queryable.SelectContext(ctx, dest, query, args...) // nolint:wrapcheck
+}
+
+func (t *TxQueryable) NamedExecContext(ctx context.Context, query string, arg any) (sql.Result, error) {
+	t.Lock()
+	defer t.Unlock()
+
+	return t.Queryable.NamedExecContext(ctx, query, arg) // nolint:wrapcheck
+}
+
+func (t *TxQueryable) PrepareNamedContext(ctx context.Context, query string) (*sqlx.NamedStmt, error) {
+	t.Lock()
+	defer t.Unlock()
+
+	return t.Queryable.PrepareNamedContext(ctx, query) // nolint:wrapcheck
+}
+
+func (t *TxQueryable) PreparexContext(ctx context.Context, query string) (*sqlx.Stmt, error) {
+	t.Lock()
+	defer t.Unlock()
+
+	return t.Queryable.PreparexContext(ctx, query) // nolint:wrapcheck
+}

--- a/pkg/psql/transactor_test.go
+++ b/pkg/psql/transactor_test.go
@@ -1,0 +1,75 @@
+package psql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/arthureichelberger/goboiler/pkg/psql"
+	"github.com/arthureichelberger/goboiler/pkg/test"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestWithinTransaction(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	db, err := psql.Connect(ctx, "postgres", "postgres", "localhost", "5432", "postgres")
+	require.NoError(t, err)
+
+	txn, rollback := test.Txn(t, ctx, db)
+	defer rollback()
+
+	_, err = txn(ctx).ExecContext(ctx, `CREATE TABLE transactor_transactions (id SERIAL PRIMARY KEY, name TEXT NOT NULL);`)
+	require.NoError(t, err)
+
+	transactor := psql.NewTransactor(txn(ctx))
+
+	t.Run("it should rollback the transaction", func(t *testing.T) {
+		err = transactor.WithinTransaction(ctx, func(ctx context.Context) error {
+			_, err := txn(ctx).ExecContext(ctx, `INSERT INTO transactor_transactions DEFAULT VALUES;`)
+			require.Error(t, err)
+
+			return err
+		})
+		require.Error(t, err)
+
+		var count int
+		err = txn(ctx).GetContext(ctx, &count, `SELECT COUNT(*) FROM transactor_transactions`)
+		require.NoError(t, err)
+		require.Equal(t, 0, count)
+	})
+
+	t.Run("it should commit the transaction", func(t *testing.T) {
+		err = transactor.WithinTransaction(ctx, func(ctx context.Context) error {
+			_, err = txn(ctx).ExecContext(ctx, `INSERT INTO transactor_transactions (name) VALUES ('test');`)
+			require.NoError(t, err)
+
+			return nil
+		})
+		require.NoError(t, err)
+
+		var count int
+		err = txn(ctx).GetContext(ctx, &count, `SELECT COUNT(*) FROM transactor_transactions`)
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+	})
+
+	t.Run("it should work with concurrent access", func(t *testing.T) {
+		err := transactor.WithinTransaction(ctx, func(ctx context.Context) error {
+			g, gCtx := errgroup.WithContext(ctx)
+
+			for i := 0; i < 10; i++ {
+				g.Go(func() error {
+					var c int
+					return txn(gCtx).GetContext(gCtx, &c, `SELECT COUNT(*) FROM transactor_transactions`)
+				})
+			}
+
+			return g.Wait()
+		})
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
Transactor is a way to embed some database calls from multiple stores inside a postgres transaction.